### PR TITLE
Fix a overloaded max is ambiguous.

### DIFF
--- a/mpreal.h
+++ b/mpreal.h
@@ -3106,7 +3106,7 @@ inline const mpreal pow(const double a, const int b, mp_rnd_t rnd_mode)
 // Non-throwing swap C++ idiom: http://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Non-throwing_swap
 namespace std
 {
-    inline const mpfr::mpreal& min(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan = false)
+    inline const mpfr::mpreal& min(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan)
     {
         if(omitnan)
         {
@@ -3122,7 +3122,7 @@ namespace std
         return a <= b ? a : b;
     }
 
-    inline const mpfr::mpreal& max(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan = false)
+    inline const mpfr::mpreal& max(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan)
     {
         if(omitnan)
         {


### PR DESCRIPTION
The code

    typedef mpfr::mpreal real;
    using std::max;
    real a = 1, b = 2;
    real c = max(a,b);

gives

  error: call of overloaded ‘max(real&, real&)’ is ambiguous

There are 3 candidates are

../mpreal.h:3125:32: note: candidate: ‘const mpfr::mpreal& std::max(const mpfr::mpreal&, const mpfr::mpreal&, bool)’
/usr/include/c++/9/bits/stl_algobase.h:222:5: note: candidate: ‘constexpr const _Tp& std::max(const _Tp&, const _Tp&) [with _Tp = mpfr::mpreal]’
../mpreal.h:2660:22: note: candidate: ‘const mpfr::mpreal
mpfr::max(const mpfr::mpreal&, const mpfr::mpreal&)’

making the "omitnan" args to the name std::max/min required fixes the
problem.

(I need the "using std::max", so that when real is a double, std::max
gets invoked.)