### PR TITLE
Make omitnan argument to min+max a required arg.

### DIFF
--- a/mpreal.h
+++ b/mpreal.h
@@ -3108,7 +3108,7 @@ inline const mpreal pow(const double a, const int b, mp_rnd_t rnd_mode)
 // Non-throwing swap C++ idiom: http://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Non-throwing_swap
 namespace std
 {
-    inline const mpfr::mpreal& min(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan = false)
+    inline const mpfr::mpreal& min(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan)
     {
         if(omitnan)
         {
@@ -3121,10 +3121,10 @@ namespace std
             else if(isnan(b)) return b;
         }
 
-        return a <= b ? a : b;
+        return (b < a) ? b : a;
     }
 
-    inline const mpfr::mpreal& max(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan = false)
+    inline const mpfr::mpreal& max(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan)
     {
         if(omitnan)
         {
@@ -3137,7 +3137,7 @@ namespace std
             else if(isnan(b)) return b;
         }
 
-        return a >= b ? a : b;
+        return (a < b) ? b : a;
     }
 
 


### PR DESCRIPTION
These declarations are now no longer in conflict with those in the
algorithm header.  This fixes issue #9.

At the same time I made the return value use the `<` operator so that it
aligns with the suggested implementations in

  https://en.cppreference.com/w/cpp/algorithm/min
  https://en.cppreference.com/w/cpp/algorithm/max