### PR TITLE
Minmax fix

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,5 @@
 2022-01-18  Pavel Holoborodko  <pavel@holoborodko.com>
-	
+
 	* Fixed incompatibility with MPFR 4.2.0 by disabling MPFR_SRCPTR macro.
 	* Removed unnecessary min/max overloads from std namespace.
 	* Added new functions from MPFR 4.0.0 for incomplete gamma (gammainc) and beta (beta) functions.

--- a/mpreal.h
+++ b/mpreal.h
@@ -3108,7 +3108,7 @@ inline const mpreal pow(const double a, const int b, mp_rnd_t rnd_mode)
 // Non-throwing swap C++ idiom: http://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Non-throwing_swap
 namespace std
 {
-    inline const mpfr::mpreal& min(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan = false)
+    inline const mpfr::mpreal& min(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan)
     {
         if(omitnan)
         {
@@ -3121,10 +3121,10 @@ namespace std
             else if(isnan(b)) return b;
         }
 
-        return a <= b ? a : b;
+        return (b < a) ? b : a;
     }
 
-    inline const mpfr::mpreal& max(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan = false)
+    inline const mpfr::mpreal& max(const mpfr::mpreal& a, const mpfr::mpreal& b, bool omitnan)
     {
         if(omitnan)
         {
@@ -3137,7 +3137,7 @@ namespace std
             else if(isnan(b)) return b;
         }
 
-        return a >= b ? a : b;
+        return (a < b) ? b : a;
     }
 
 

--- a/mpreal.h
+++ b/mpreal.h
@@ -2763,8 +2763,8 @@ inline int sgn(const mpreal& op)
 //////////////////////////////////////////////////////////////////////////
 // Miscellaneous Functions
 inline void         swap (mpreal& a, mpreal& b)            {    mpfr_swap(a.mpfr_ptr(),b.mpfr_ptr());   }
-inline const mpreal (max)(const mpreal& x, const mpreal& y){    return (x>y?x:y);       }
-inline const mpreal (min)(const mpreal& x, const mpreal& y){    return (x<y?x:y);       }
+inline const mpreal (max)(const mpreal& x, const mpreal& y){    return (x<y?y:x);       }
+inline const mpreal (min)(const mpreal& x, const mpreal& y){    return (y<x?y:x);       }
 
 inline const mpreal fmax(const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
 {


### PR DESCRIPTION
Fix min/max to return first argument if values are equivalent

This convention adheres to the standard.  Thus
    
      min(nan, 3) => nan
    
See, e.g.,
* https://en.cppreference.com/w/cpp/algorithm/min
* https://en.cppreference.com/w/cpp/algorithm/max
