### PR TITLE
Fix min/max to return first argument if values are equivalent

### DIFF
--- a/mpreal.h
+++ b/mpreal.h
@@ -2763,8 +2763,8 @@ inline int sgn(const mpreal& op)
 //////////////////////////////////////////////////////////////////////////
 // Miscellaneous Functions
 inline void         swap (mpreal& a, mpreal& b)            {    mpfr_swap(a.mpfr_ptr(),b.mpfr_ptr());   }
-inline const mpreal (max)(const mpreal& x, const mpreal& y){    return (x>y?x:y);       }
-inline const mpreal (min)(const mpreal& x, const mpreal& y){    return (x<y?x:y);       }
+inline const mpreal (max)(const mpreal& x, const mpreal& y){    return (x<y?y:x);       }
+inline const mpreal (min)(const mpreal& x, const mpreal& y){    return (y<x?y:x);       }
 
 inline const mpreal fmax(const mpreal& x, const mpreal& y, mp_rnd_t rnd_mode = mpreal::get_default_rnd())
 {


### PR DESCRIPTION
This convention adheres to the standard.  Thus

  min(nan, 3) => nan

See, e.g.,

  https://en.cppreference.com/w/cpp/algorithm/min
  https://en.cppreference.com/w/cpp/algorithm/max